### PR TITLE
Feature Logout

### DIFF
--- a/client/src/features/auth/Logout.jsx
+++ b/client/src/features/auth/Logout.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+/**
+ * This component should be a button that when clicked opens a modal 
+ * which has details of logging out of their account and a button, when
+ * clicked, sends a POST /auth/logout which removes the users token from
+ * the browsers cookie.
+ */
+export const Logout = () => {
+  return (
+    <div>Logout</div>
+  )
+}

--- a/server/src/routes/auth/__tests__/logout.test.ts
+++ b/server/src/routes/auth/__tests__/logout.test.ts
@@ -1,0 +1,34 @@
+import { MAX_AGE } from "cookies";
+import { generateAuthToken } from "sessions";
+import { request } from "test/server";
+
+let token: string | null = null;
+
+beforeAll(async () => {
+  token = await generateAuthToken({
+    createdAt: new Date().toString(),
+    maxAge: MAX_AGE,
+    account: {
+      account_id: "1",
+      name: "Tester",
+      email: "tester@malloyfit.ca",
+      active: false,
+      avatar_url:
+        "https://lh3.googleusercontent.com/a-/AOh14GgumKfRBh0AY4W13SE5EtwiFavA-FFGwxYTZkeX9Q=s96-c",
+      role: null,
+      ticket: "ticket-goes-here",
+      ticket_expiry: new Date().toString(),
+    },
+  });
+});
+
+describe("POST /auth/logout", function () {
+  it("responds with 302 redirected to /login", async function () {
+    const res = await request
+      .post("/auth/logout")
+      .set("Accept", "application/json")
+      .set("Cookie", [`token=${token}`]);
+
+    expect(res.status).toEqual(302);
+  });
+});

--- a/server/src/routes/auth/index.ts
+++ b/server/src/routes/auth/index.ts
@@ -1,10 +1,13 @@
 import { Router } from "express";
+import logout from "./logout";
 import me from "./me";
 import providers from "./providers";
 
 const router = Router();
+
 providers(router);
-me(router)
+me(router);
+logout(router);
 
 export default (parentRouter: Router) => {
   parentRouter.use("/auth", router);

--- a/server/src/routes/auth/logout.ts
+++ b/server/src/routes/auth/logout.ts
@@ -1,0 +1,14 @@
+import { removeTokenCookie } from "cookies";
+import { Router } from "express";
+
+const router = Router();
+
+// Logout user
+router.post("/", async (req, res) => {
+  removeTokenCookie(res);
+  res.redirect("/login");
+});
+
+export default (parentRouter: Router) => {
+  parentRouter.use("/logout", router);
+};


### PR DESCRIPTION
Adds logout functionality to the app. By sending a `POST /auth/logout` we clear the token in the browser cookie. 
The cookie is what we user to identify the user as it stores data about them such as their accound_id, email, name, profile picture, etc. 

You should be able to visit the *application* tab in chrome and click on `http://localhost:3000/` in the left panel to see the cookie. 
When you make a request to POST /auth/logout, notice that cookie is cleared. 