### PR TITLE
Feature Exercise Muscle Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Endpoints for viewing and manipulating exercises.
 - [Create an exercise](docs/exercises/post.md) : `POST /exercises/`
 - [Update an exercise](docs/exercises/put.md) : `PUT /exercises/:pk/`
 - [Delete an exercise](docs/exercises/delete.md) : `DELETE /exercises/:pk/`
+- [Add a muscle-group to an exercise](docs/exercises/muscle-groups/post.md) : `POST /exercises/:pk/muscle-group`
+- [Remvoes a primary muscle-group from an exercise](docs/exercises/muscle-groups/delete.md) : `DELETE /exercises/:pk/muscle-group/:pk/primary`
+- [Removes a secondary muscle-group from an exercise](docs/exercises/muscle-groups/delete.md) : `DELETE /exercises/:pk/muscle-group/:pk/secondary`
 
 ### Sets
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Endpoints for viewing and manipulating exercises.
 - [Update an exercise](docs/exercises/put.md) : `PUT /exercises/:pk/`
 - [Delete an exercise](docs/exercises/delete.md) : `DELETE /exercises/:pk/`
 - [Add a muscle-group to an exercise](docs/exercises/muscle-groups/post.md) : `POST /exercises/:pk/muscle-group`
-- [Remvoes a primary muscle-group from an exercise](docs/exercises/muscle-groups/delete.md) : `DELETE /exercises/:pk/muscle-group/:pk/primary`
+- [Removes a primary muscle-group from an exercise](docs/exercises/muscle-groups/delete.md) : `DELETE /exercises/:pk/muscle-group/:pk/primary`
 - [Removes a secondary muscle-group from an exercise](docs/exercises/muscle-groups/delete.md) : `DELETE /exercises/:pk/muscle-group/:pk/secondary`
 
 ### Sets

--- a/server/src/middlewares/admin.ts
+++ b/server/src/middlewares/admin.ts
@@ -1,0 +1,18 @@
+import { NextFunction, Response, Request } from "express";
+import { authorizeAdminQuery } from "queries/authorizeAdminQuery";
+
+/**
+ * Checks the DB for role to authorize resource.
+ * If authorized as an admin, continue, if not, send back a 403 Forbidden.
+ */
+export const admin = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const { isAdmin } = await authorizeAdminQuery(res);
+  if (isAdmin) {
+    return next();
+  }
+  return res.status(403).json({ message: "Unauthorized" });
+};

--- a/server/src/queries/addMuscleGroupToExercise.ts
+++ b/server/src/queries/addMuscleGroupToExercise.ts
@@ -1,0 +1,71 @@
+import { db } from "config/db";
+import { Response } from "express";
+import Joi from "joi";
+
+interface addMuscleGroup {
+  group: "primary" | "secondary";
+  muscleGroupId: number | string;
+}
+
+const addMuscleGroupSchema = Joi.object({
+  group: Joi.string().valid("primary", "secondary").optional(),
+  muscleGroupId: Joi.alternatives(Joi.string(), Joi.number()).required(),
+});
+
+export const addMuscleGroupToExercise = async (
+  res: Response,
+  data: addMuscleGroup,
+  exerciseId: string
+) => {
+  const { error, value, warning } = addMuscleGroupSchema.validate(data);
+
+  if (error) {
+    return res.status(422).json({
+      status: "error",
+      message: "Invalid request data",
+      muscleGroup: value,
+      error: error,
+    });
+  } else {
+    const { muscleGroupId, group } = data;
+
+    if (Number.isNaN(parseInt(muscleGroupId.toString()))) {
+      return res.status(422).json({
+        status: "error",
+        //@ts-ignore
+        message: "Invalid muscleGroup ID",
+      });
+    }
+
+    const query = `
+    WITH
+    data(exercise_id, muscle_group_id, "group") AS (
+      VALUES
+          (${exerciseId}, ${muscleGroupId}, '${group}')
+      )
+    INSERT INTO exercise_muscle_groups (exercise_id, muscle_group_id, "group")
+      SELECT exercise_id, muscle_group_id, "group"
+        FROM data
+      RETURNING *
+      `;
+
+    try {
+      const data = await db.query(query);
+      const muscleGroup = data.rows[0];
+
+      return res.status(201).json({
+        status: "success",
+        message: "Muscle-group added successfully",
+        muscleGroup,
+      });
+    } catch (error) {
+      console.log({ error });
+      return res.status(500).json({
+        status: "error",
+        //@ts-ignore
+        message: error && error.message ? error.message : "Database error",
+        muscleGroup: null,
+      });
+    }
+  }
+};

--- a/server/src/queries/authorizeAdminQuery.ts
+++ b/server/src/queries/authorizeAdminQuery.ts
@@ -1,0 +1,31 @@
+import { db } from "config/db";
+import { Response } from "express";
+
+export const authorizeAdminQuery = async (
+  res: Response
+): Promise<{
+  isAdmin: boolean;
+}> => {
+  const accountId = res.locals.state.account.account_id;
+
+  const query = `SELECT * FROM accounts WHERE account_id = $1 AND role = 'developer'`;
+  const params = [accountId];
+
+  try {
+    const data = await db.query(query, params);
+    if (!data.rows.length) {
+      return {
+        isAdmin: false,
+      };
+    }
+
+    return {
+      isAdmin: true,
+    };
+  } catch (error) {
+    console.log({ error });
+    return {
+      isAdmin: false,
+    };
+  }
+};

--- a/server/src/queries/removeMuscleGroupFromExercise.ts
+++ b/server/src/queries/removeMuscleGroupFromExercise.ts
@@ -1,0 +1,36 @@
+import { db } from "config/db";
+import { Response } from "express";
+
+export const removeMuscleGroupFromExercise = async (
+  res: Response,
+  exerciseId: string,
+  muscleGroupId: string,
+  group: "primary" | "secondary"
+) => {
+  const query = `DELETE FROM exercise_muscle_groups WHERE exercise_id = $1 AND muscle_group_id = $2 AND "group" = $3 RETURNING *;`;
+  const params = [exerciseId, muscleGroupId, group];
+  try {
+    const data = await db.query(query, params);
+
+    if (!data.rowCount) {
+      return res.status(404).json({
+        status: "error",
+        message: "Muscle-group does not exist",
+        muscleGroup: null,
+      });
+    }
+
+    return res.status(200).json({
+      status: "success",
+      message: "Muscle-group removed successfully",
+      muscleGroup: data.rows[0],
+    });
+  } catch (error) {
+    console.log({ error });
+    return res.status(500).json({
+      status: "error",
+      message: "Database error",
+      muscleGroup: null,
+    });
+  }
+};

--- a/server/src/routes/exercises/index.ts
+++ b/server/src/routes/exercises/index.ts
@@ -6,6 +6,7 @@ import { deleteExerciseMutation } from "queries/deleteExerciseMutation";
 import { retrieveExerciseQuery } from "queries/retrieveExerciseQuery";
 import { retrieveExercisesQuery } from "queries/retrieveExercisesQuery";
 import { updateExerciseMutation } from "queries/updateExerciseMutation";
+import muscleGroups from "./muscle-groups";
 
 const router = Router();
 
@@ -34,6 +35,8 @@ router.delete("/:exerciseId", authenticate, authorize, async (req, res) => {
 router.put("/:exerciseId", authenticate, authorize, async (req, res) => {
   await updateExerciseMutation(res, req.body, req.params.exerciseId);
 });
+
+muscleGroups(router);
 
 export default (parentRouter: Router) => {
   parentRouter.use("/exercises", router);

--- a/server/src/routes/exercises/muscle-groups/__tests__/exercise-muscle-groups.test.ts
+++ b/server/src/routes/exercises/muscle-groups/__tests__/exercise-muscle-groups.test.ts
@@ -1,0 +1,154 @@
+import { MAX_AGE } from "cookies";
+import { generateAuthToken } from "sessions";
+import { request } from "test/server";
+
+let token: string | null = null;
+let deletable: string | null = null;
+let deletable2: string | null = null;
+
+beforeAll(async () => {
+  token = await generateAuthToken({
+    createdAt: new Date().toString(),
+    maxAge: MAX_AGE,
+    account: {
+      account_id: "1",
+      name: "Tester",
+      email: "tester@malloyfit.ca",
+      active: false,
+      avatar_url:
+        "https://lh3.googleusercontent.com/a-/AOh14GgumKfRBh0AY4W13SE5EtwiFavA-FFGwxYTZkeX9Q=s96-c",
+      role: null,
+      ticket: "ticket-goes-here",
+      ticket_expiry: new Date().toString(),
+    },
+  });
+});
+
+describe("POST /exercises/:pk/muscle-group", function () {
+  it("responds with 401 Unauthenticated", async function () {
+    const res = await request
+      .post("/exercises/1000/muscle-group/")
+      .send({
+        group: "primary",
+        muscleGroupId: 1000,
+      })
+      .set("Accept", "application/json");
+
+    expect(res.status).toEqual(401);
+  });
+
+  it("responds with 422 unprocessable entity", async function () {
+    const res = await request
+      .post("/exercises/1000/muscle-group")
+      .send({
+        group: "invalid-group",
+        muscleGroupId: 1000,
+      })
+      .set("Accept", "application/json")
+      .set("Cookie", [`token=${token}`]);
+
+    expect(res.status).toEqual(422);
+  });
+
+  it("responds with 201 success with primary group", async function () {
+    const res = await request
+      .post("/exercises/1000/muscle-group")
+      .send({
+        group: "primary",
+        muscleGroupId: 1000,
+      })
+      .set("Accept", "application/json")
+      .set("Cookie", [`token=${token}`]);
+
+    deletable = res.body.muscleGroup.muscle_group_id;
+    expect(res.status).toEqual(201);
+  });
+
+  it("responds with 201 success with secondary group", async function () {
+    const res = await request
+      .post("/exercises/1000/muscle-group")
+      .send({
+        group: "secondary",
+        muscleGroupId: 1000,
+      })
+      .set("Accept", "application/json")
+      .set("Cookie", [`token=${token}`]);
+
+    deletable2 = res.body.muscleGroup.muscle_group_id;
+    expect(res.status).toEqual(201);
+  });
+});
+
+describe("DELETE /exercises/:pk/muscle-group/:pk/primary", function () {
+  it("responds with 401 Unauthenticated", async function () {
+    const res = await request
+      .delete("/exercises/1000/muscle-group/1000/primary")
+      .set("Accept", "application/json");
+
+    expect(res.status).toEqual(401);
+  });
+
+  it("responds with 403 Unauthorized", async function () {
+    const res = await request
+      .delete("/exercises/1003/muscle-group/1003/primary")
+      .set("Accept", "application/json")
+      .set("Cookie", [`token=${token}`]);
+
+    expect(res.status).toEqual(403);
+  });
+
+  it("responds with 200 successfully deleted", async function () {
+    const res = await request
+      .delete(`/exercises/1000/muscle-group/${deletable}/primary`)
+      .set("Accept", "application/json")
+      .set("Cookie", [`token=${token}`]);
+
+    expect(res.status).toEqual(200);
+  });
+
+  it("responds with 404 not found", async function () {
+    const res = await request
+      .delete(`/exercises/1000/muscle-group/${deletable}/primary`)
+      .set("Accept", "application/json")
+      .set("Cookie", [`token=${token}`]);
+
+    expect(res.status).toEqual(404);
+  });
+});
+
+describe("DELETE /exercises/:pk/muscle-group/:pk/secondary", function () {
+  it("responds with 401 Unauthenticated", async function () {
+    const res = await request
+      .delete("/exercises/1000/muscle-group/1000/secondary")
+      .set("Accept", "application/json");
+
+    expect(res.status).toEqual(401);
+  });
+
+  it("responds with 403 Unauthorized", async function () {
+    const res = await request
+      .delete("/exercises/1003/muscle-group/1003/secondary")
+      .set("Accept", "application/json")
+      .set("Cookie", [`token=${token}`]);
+
+    expect(res.status).toEqual(403);
+  });
+
+  it("responds with 200 successfully deleted", async function () {
+    const res = await request
+      .delete(`/exercises/1000/muscle-group/${deletable2}/secondary`)
+      .set("Accept", "application/json")
+      .set("Cookie", [`token=${token}`]);
+
+    expect(res.status).toEqual(200);
+  });
+
+  it("responds with 404 not found", async function () {
+    const res = await request
+      .delete(`/exercises/1000/muscle-group/${deletable2}/secondary`)
+      .set("Accept", "application/json")
+      .set("Cookie", [`token=${token}`]);
+
+    expect(res.status).toEqual(404);
+  });
+});

--- a/server/src/routes/exercises/muscle-groups/index.ts
+++ b/server/src/routes/exercises/muscle-groups/index.ts
@@ -1,0 +1,51 @@
+import { Router } from "express";
+import { authenticate } from "middlewares/authenticate";
+import { authorize } from "middlewares/authorize";
+import { addMuscleGroupToExercise } from "queries/addMuscleGroupToExercise";
+import { removeMuscleGroupFromExercise } from "queries/removeMuscleGroupFromExercise";
+
+const router = Router();
+
+// Add muscle-group to the exercise
+router.post(
+  "/:exerciseId/muscle-group/",
+  authenticate,
+  authorize,
+  async (req, res) => {
+    await addMuscleGroupToExercise(res, req.body, req.params.exerciseId);
+  }
+);
+
+// Remove primary muscle-group from the exercise
+router.delete(
+  "/:exerciseId/muscle-group/:muscleGroupId/primary",
+  authenticate,
+  authorize,
+  async (req, res) => {
+    await removeMuscleGroupFromExercise(
+      res,
+      req.params.exerciseId,
+      req.params.muscleGroupId,
+      "primary"
+    );
+  }
+);
+
+// Remove secondary muscle-group from the exercise
+router.delete(
+  "/:exerciseId/muscle-group/:muscleGroupId/secondary",
+  authenticate,
+  authorize,
+  async (req, res) => {
+    await removeMuscleGroupFromExercise(
+      res,
+      req.params.exerciseId,
+      req.params.muscleGroupId,
+      "secondary"
+    );
+  }
+);
+
+export default (parentRouter: Router) => {
+  parentRouter.use("/", router);
+};


### PR DESCRIPTION
In this PR you can now add / remove muscle-groups from exercises. 

New API routes:

Adds a muscle-group to an exercise `POST /exercises/:pk/muscle-group`
Removes a primary muscle-group from an exercise `DELETE /exercises/:pk/muscle-group/:pk/primary`
Removes a secondary muscle-group from an exercise `DELETE /exercises/:pk/muscle-group/:pk/secondary`