### PR TITLE
Feature/workout exercise metadata

### DIFF
--- a/server/db/0_create_tables.sql
+++ b/server/db/0_create_tables.sql
@@ -42,6 +42,10 @@ CREATE TABLE IF NOT EXISTS workout_exercises (
     priority int DEFAULT 1,
     "order" int DEFAULT 1,
     notes text,
+    sets text,
+    repetitions text,
+    reps_in_reserve text,
+    rest_period text,
     UNIQUE (workout_id, exercise_id)
 );
 

--- a/server/src/queries/updateWorkoutExerciseMetadataMutation.ts
+++ b/server/src/queries/updateWorkoutExerciseMetadataMutation.ts
@@ -35,8 +35,6 @@ export const updateWorkoutExerciseMetadataMutation = async (
       data,
     });
 
-    console.log({ query, params });
-
     try {
       const data = await db.query(query, params);
       if (!data.rowCount) {

--- a/server/src/queries/updateWorkoutExerciseMetadataMutation.ts
+++ b/server/src/queries/updateWorkoutExerciseMetadataMutation.ts
@@ -1,0 +1,61 @@
+import { db } from 'config/db';
+import Joi from 'joi';
+import { update } from 'utils/update';
+import { Response } from 'express';
+
+const updateWorkoutExerciseSchema = Joi.object({
+  notes: Joi.string().optional(),
+  sets: Joi.string().optional(),
+  repetitions: Joi.string().optional(),
+  reps_in_reserve: Joi.string().optional(),
+  rest_period: Joi.string().optional(),
+});
+
+export const updateWorkoutExerciseMetadataMutation = async (
+  res: Response,
+  data: Record<string, string>,
+  workoutId: string,
+  exerciseId: string
+) => {
+  const { error, value, warning } = updateWorkoutExerciseSchema.validate(data);
+  if (error) {
+    return res.status(422).json({
+      status: 'error',
+      message: 'Invalid request data',
+      exercise: value,
+      error: error,
+    });
+  } else {
+    const { query, params } = update({
+      tableName: 'workout_exercises',
+      conditions: {
+        workout_id: workoutId,
+        exercise_id: exerciseId,
+      },
+      data,
+    });
+
+    console.log({ query, params });
+
+    try {
+      const data = await db.query(query, params);
+      if (!data.rowCount) {
+        return res.status(404).json({
+          status: 'error',
+          message: 'Exercise does not exist',
+        });
+      }
+
+      return res.status(200).json({
+        status: 'success',
+        message: 'Exercise updated successfully',
+      });
+    } catch (error) {
+      console.log({ error });
+      return res.status(500).json({
+        status: 'error',
+        message: 'Database error',
+      });
+    }
+  }
+};

--- a/server/src/queries/updateWorkoutExerciseMutation.ts
+++ b/server/src/queries/updateWorkoutExerciseMutation.ts
@@ -1,6 +1,5 @@
-import { db } from "config/db";
-import Joi from "joi";
-import { update } from "utils/update";
+import { db } from 'config/db';
+import Joi from 'joi';
 
 interface Response {
   status: string;
@@ -23,8 +22,8 @@ export const updateWorkoutExerciseMutation = async (
   const { error, value, warning } = updateWorkoutExerciseSchema.validate(data);
   if (error) {
     return res.status(422).json({
-      status: "error",
-      message: "Invalid request data",
+      status: 'error',
+      message: 'Invalid request data',
       exercise: value,
       error: error,
     });
@@ -32,21 +31,21 @@ export const updateWorkoutExerciseMutation = async (
     const { order, priority } = data;
 
     if (
-      (typeof order === "number" && order < 0) ||
-      (typeof priority === "number" && priority < 0)
+      (typeof order === 'number' && order < 0) ||
+      (typeof priority === 'number' && priority < 0)
     ) {
       return res.status(422).json({
-        status: "error",
-        message: "Only positive numbers allowed for weight and reps",
+        status: 'error',
+        message: 'Only positive numbers allowed for weight and reps',
         exercise: null,
       });
     }
 
     if (!order && !priority) {
       return res.status(422).json({
-        status: "error",
+        status: 'error',
         message:
-          "Both order and priority were missing or were coerced to false. One of order or priority is required to update the exercise within the workout.",
+          'Both order and priority were missing or were coerced to false. One of order or priority is required to update the exercise within the workout.',
         exercise: null,
       });
     }
@@ -78,22 +77,22 @@ export const updateWorkoutExerciseMutation = async (
       const data = await db.query(query, params);
       if (!data.rowCount) {
         return res.status(404).json({
-          status: "error",
-          message: "Exercise does not exist",
+          status: 'error',
+          message: 'Exercise does not exist',
           exercise: null,
         });
       }
 
       return res.status(200).json({
-        status: "success",
-        message: "Exercise updated successfully",
+        status: 'success',
+        message: 'Exercise updated successfully',
         exercise: data.rows[0],
       });
     } catch (error) {
       console.log({ error });
       return res.status(500).json({
-        status: "error",
-        message: "Database error",
+        status: 'error',
+        message: 'Database error',
         exercise: null,
       });
     }

--- a/server/src/routes/workouts/exercises/__tests__/workout-exercises.test.ts
+++ b/server/src/routes/workouts/exercises/__tests__/workout-exercises.test.ts
@@ -68,6 +68,33 @@ describe('POST /workouts/:pk/exercises', function () {
   });
 });
 
+describe('PATCH /workouts/:pk/exercises/:pk - update workout-exercise metadata', function () {
+  it('responds with 401 Unauthenticated', async function () {
+    const res = await request
+      .put(`/workouts/1000/exercises/${deletable}`)
+      .send({
+        order: 2,
+        priority: 2,
+      })
+      .set('Accept', 'application/json');
+
+    expect(res.status).toEqual(401);
+  });
+
+  it('responds with 403 Unauthorized', async function () {
+    const res = await request
+      .put(`/workouts/1003/exercises/${deletable}`)
+      .send({
+        order: 2,
+        priority: 2,
+      })
+      .set('Accept', 'application/json')
+      .set('Cookie', [`token=${token}`]);
+
+    expect(res.status).toEqual(403);
+  });
+});
+
 describe('PUT /workouts/:pk/exercises/:pk', function () {
   it('responds with 401 Unauthenticated', async function () {
     const res = await request

--- a/server/src/routes/workouts/exercises/__tests__/workout-exercises.test.ts
+++ b/server/src/routes/workouts/exercises/__tests__/workout-exercises.test.ts
@@ -71,7 +71,7 @@ describe('POST /workouts/:pk/exercises', function () {
 describe('PATCH /workouts/:pk/exercises/:pk - update workout-exercise metadata', function () {
   it('responds with 401 Unauthenticated', async function () {
     const res = await request
-      .put(`/workouts/1000/exercises/${deletable}`)
+      .patch(`/workouts/1000/exercises/${deletable}`)
       .send({
         order: 2,
         priority: 2,
@@ -83,7 +83,7 @@ describe('PATCH /workouts/:pk/exercises/:pk - update workout-exercise metadata',
 
   it('responds with 403 Unauthorized', async function () {
     const res = await request
-      .put(`/workouts/1003/exercises/${deletable}`)
+      .patch(`/workouts/1003/exercises/${deletable}`)
       .send({
         order: 2,
         priority: 2,
@@ -92,6 +92,34 @@ describe('PATCH /workouts/:pk/exercises/:pk - update workout-exercise metadata',
       .set('Cookie', [`token=${token}`]);
 
     expect(res.status).toEqual(403);
+  });
+
+  it('responds with 422 unprocessable entity', async function () {
+    const res = await request
+      .patch(`/workouts/1000/exercises/${deletable}`)
+      .send({
+        order: 2,
+      })
+      .set('Accept', 'application/json')
+      .set('Cookie', [`token=${token}`]);
+
+    expect(res.status).toEqual(422);
+  });
+
+  it('responds with 200 success', async function () {
+    const res = await request
+      .patch(`/workouts/1000/exercises/${deletable}`)
+      .send({
+        notes: 'update notes',
+        sets: '2',
+        repetitions: '10-12',
+        reps_in_reserve: '1',
+        rest_period: '120 seconds',
+      })
+      .set('Accept', 'application/json')
+      .set('Cookie', [`token=${token}`]);
+
+    expect(res.status).toEqual(200);
   });
 });
 
@@ -121,7 +149,7 @@ describe('PUT /workouts/:pk/exercises/:pk', function () {
     expect(res.status).toEqual(403);
   });
 
-  it('responds with 200 successfully updated', async function () {
+  it('responds with 422 unprocessable entity', async function () {
     const res = await request
       .put(`/workouts/1000/exercises/${deletable}`)
       .send({})

--- a/server/src/routes/workouts/exercises/index.ts
+++ b/server/src/routes/workouts/exercises/index.ts
@@ -4,6 +4,7 @@ import { authorize } from 'middlewares/authorize';
 import { addExerciseToWorkoutMutation } from 'queries/addExerciseToWorkoutMutation';
 import { removeExerciseFromWorkoutMutation } from 'queries/removeExerciseFromWorkoutMutation';
 import { retrieveExerciseWorkoutQuery } from 'queries/retrieveExerciseWorkoutQuery';
+import { updateWorkoutExerciseMetadataMutation } from 'queries/updateWorkoutExerciseMetadataMutation';
 import { updateWorkoutExerciseMutation } from 'queries/updateWorkoutExerciseMutation';
 
 const router = Router();
@@ -43,6 +44,21 @@ router.put(
   authorize,
   async (req, res) => {
     await updateWorkoutExerciseMutation(
+      res,
+      req.body,
+      req.params.workoutId,
+      req.params.exerciseId
+    );
+  }
+);
+
+// Update exercise metadata in the workout
+router.patch(
+  '/:workoutId/exercises/:exerciseId',
+  authenticate,
+  authorize,
+  async (req, res) => {
+    await updateWorkoutExerciseMetadataMutation(
       res,
       req.body,
       req.params.workoutId,


### PR DESCRIPTION
Serverside:
Adds a PATCH request to `PATCH /workouts/:pk/exercise/:pk` with body of 
```
{
   notes: "",
  sets: "",
  repetitions: "",
  reps_in_reserve: "",
  rest_period: ""
}
```

All properties do not have to be present on the body, just have to match the keys presented above.