### PR TITLE
Feature/ exercise muscle-groups

### DIFF
--- a/client/src/features/exercises/ExerciseList.jsx
+++ b/client/src/features/exercises/ExerciseList.jsx
@@ -37,8 +37,6 @@ export const ExerciseList = ({ query }) => {
     return <p>none available...</p>;
   }
 
-  console.log({ data });
-
   return (
     <div>
       {data.exercises.map((exercise) => (
@@ -79,7 +77,7 @@ export const ExerciseList = ({ query }) => {
             </div>
           </Link>
           {exercise.view === 'private' && (
-            <UpdateExercise exercise={exercise} />
+            <UpdateExercise exercise={exercise} queryKey="fetchExercises" />
           )}
         </div>
       ))}

--- a/client/src/features/exercises/GetSingleExercise.jsx
+++ b/client/src/features/exercises/GetSingleExercise.jsx
@@ -45,6 +45,7 @@ export const GetSingleExercise = ({ id }) => {
       <UpdateExercise
         exercise={data.exercise}
         muscleGroups={mgData.muscleGroups}
+        queryKey="fetchExercise"
       />
       <DeleteExercise exerciseId={data.exercise.exercise_id} />
     </div>

--- a/client/src/features/exercises/UpdateExercise.jsx
+++ b/client/src/features/exercises/UpdateExercise.jsx
@@ -6,7 +6,7 @@ import Modal from 'features/common/Modal';
 import { UpdateExerciseForm } from './UpdateExerciseForm';
 import { useMuscleGroupsQuery } from 'features/muscle-groups/useMuscleGroupsQuery';
 
-export const UpdateExercise = ({ exercise }) => {
+export const UpdateExercise = ({ exercise, queryKey }) => {
   const [isOpen, setIsOpen] = useState(false);
   const { data, isError, isLoading } = useMuscleGroupsQuery();
 
@@ -31,6 +31,7 @@ export const UpdateExercise = ({ exercise }) => {
         <UpdateExerciseForm
           exercise={exercise}
           muscleGroups={data.muscleGroups}
+          queryKey={queryKey}
           setIsOpen={setIsOpen}
         />
       </Modal>

--- a/client/src/features/exercises/UpdateExerciseForm.jsx
+++ b/client/src/features/exercises/UpdateExerciseForm.jsx
@@ -5,8 +5,15 @@ import { useQueryClient } from 'react-query';
 import { useUpdateExerciseMutation } from './useUpdateExerciseMutation';
 import { Button } from 'features/common/Button';
 import Select from 'react-select';
+import { useAddMuscleGroupToExerciseMutation } from './useAddMuscleGroupToExerciseMutation';
+import { useRemoveMuscleGroupFromExerciseMutation } from './useRemoveMuscleGroupFromExerciseMutation';
 
-export const UpdateExerciseForm = ({ exercise, muscleGroups, setIsOpen }) => {
+export const UpdateExerciseForm = ({
+  exercise,
+  muscleGroups,
+  setIsOpen,
+  queryKey,
+}) => {
   const [name, setName] = useState(exercise.name);
   const [description, setDescription] = useState(exercise.description);
   const [category, setCategory] = useState(exercise.category);
@@ -19,6 +26,11 @@ export const UpdateExerciseForm = ({ exercise, muscleGroups, setIsOpen }) => {
     exercise.exercise_id
   );
 
+  const { mutate: addMuscleGroupMutation } =
+    useAddMuscleGroupToExerciseMutation(exercise.exercise_id);
+  const { mutate: removeMuscleGroupMutation } =
+    useRemoveMuscleGroupFromExerciseMutation(exercise.exercise_id);
+
   const queryClient = useQueryClient();
 
   const handleSubmit = (e) => {
@@ -29,19 +41,62 @@ export const UpdateExerciseForm = ({ exercise, muscleGroups, setIsOpen }) => {
       description,
       category,
       profile,
-      // primary: primary.map((object) => object.value),
-      // secondary: secondary.map((object) => object.value),
     };
 
     mutate(
       { exercise },
       {
         onSuccess: () => {
-          queryClient.refetchQueries('fetchExercises');
+          queryClient.refetchQueries(queryKey);
           setIsOpen(false);
         },
       }
     );
+  };
+
+  const updateMuscleGroup = ({ data, group }) => {
+    // get the muscle groups that are not in the primary array
+    const newPrimary = data.map((object) => object.value);
+    const oldPrimary = exercise[group].map((object) => object.muscle_group_id);
+
+    // get difference array values in newPrimary and oldPrimary
+    const difference =
+      newPrimary.length > oldPrimary.length
+        ? newPrimary.filter((x) => !oldPrimary.includes(x))
+        : oldPrimary.filter((x) => !newPrimary.includes(x));
+
+    const isAddition = newPrimary.length > oldPrimary.length;
+    const isRemove = newPrimary.length < oldPrimary.length;
+
+    if (isAddition) {
+      addMuscleGroupMutation(
+        {
+          group,
+          muscleGroupId: difference[0],
+        },
+        {
+          onSuccess: () => {
+            queryClient.refetchQueries(queryKey);
+          },
+        }
+      );
+    }
+
+    if (isRemove) {
+      for (const id of difference) {
+        removeMuscleGroupMutation(
+          {
+            group,
+            muscleGroupId: id,
+          },
+          {
+            onSuccess: () => {
+              queryClient.refetchQueries(queryKey);
+            },
+          }
+        );
+      }
+    }
   };
 
   return (
@@ -147,6 +202,7 @@ export const UpdateExerciseForm = ({ exercise, muscleGroups, setIsOpen }) => {
             }),
           }}
           onChange={(data) => {
+            updateMuscleGroup({ data, group: 'primary' });
             setPrimary(data);
             setIsPrimaryError(false);
           }}
@@ -175,7 +231,11 @@ export const UpdateExerciseForm = ({ exercise, muscleGroups, setIsOpen }) => {
               value: mg.muscle_group_id,
             };
           })}
-          onChange={(data) => setSecondary(data)}
+          onChange={(data) => {
+            updateMuscleGroup({ data, group: 'secondary' });
+            setSecondary(data);
+            setIsPrimaryError(false);
+          }}
           name="secondary-muscle-groups"
           options={muscleGroups.map((muscleGroup) => {
             return {

--- a/client/src/features/exercises/useAddMuscleGroupToExerciseMutation.jsx
+++ b/client/src/features/exercises/useAddMuscleGroupToExerciseMutation.jsx
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from 'react-query';
+
+const addMuscleGroupToExercise = async ({ exerciseId, payload }) => {
+  const res = await fetch(
+    `http://localhost:4000/exercises/${exerciseId}/muscle-group/`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      credentials: 'include',
+    }
+  );
+  const json = await res.json();
+  return json;
+};
+
+export const useAddMuscleGroupToExerciseMutation = (exerciseId) => {
+  const queryClient = useQueryClient();
+  return useMutation((payload) =>
+    addMuscleGroupToExercise({ exerciseId, payload })
+  );
+};

--- a/client/src/features/exercises/useExerciseQuery.jsx
+++ b/client/src/features/exercises/useExerciseQuery.jsx
@@ -15,7 +15,5 @@ const fetchExercise = async ({ id }) => {
 };
 
 export const useExerciseQuery = (id) => {
-  return useQuery('fetchExercise', () => fetchExercise({ id }), {
-    enabled: !!id,
-  });
+  return useQuery('fetchExercise', () => fetchExercise({ id }));
 };

--- a/client/src/features/exercises/useRemoveMuscleGroupFromExerciseMutation.jsx
+++ b/client/src/features/exercises/useRemoveMuscleGroupFromExerciseMutation.jsx
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from 'react-query';
+
+const removeMuscleGroupFromExercise = async ({
+  exerciseId,
+  muscleGroupId,
+  group,
+}) => {
+  const res = await fetch(
+    `http://localhost:4000/exercises/${exerciseId}/muscle-group/${muscleGroupId}/${group}`,
+    {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+    }
+  );
+  const json = await res.json();
+  return json;
+};
+
+export const useRemoveMuscleGroupFromExerciseMutation = (exerciseId) => {
+  const queryClient = useQueryClient();
+  return useMutation(({ group, muscleGroupId }) =>
+    removeMuscleGroupFromExercise({ exerciseId, muscleGroupId, group })
+  );
+};

--- a/server/src/queries/retrieveExerciseQuery.ts
+++ b/server/src/queries/retrieveExerciseQuery.ts
@@ -8,7 +8,12 @@ interface Response {
 
 const getMuscleGroups = async (exerciseId: string) => {
   const data = await db.query(
-    `SELECT * FROM muscle_groups mg
+    `SELECT
+      mg.name as muscle_group_name,
+      mg.description as muscle_group_description,
+      mg.muscle_group_id,
+      "group" as muscle_group
+    FROM muscle_groups mg
     JOIN exercise_muscle_groups emg ON emg.muscle_group_id = mg.muscle_group_id
   WHERE exercise_id = $1`,
     [exerciseId]
@@ -37,10 +42,29 @@ export const retrieveExerciseQuery = async (
 
     const exerciseId = data.rows[0].exercise_id;
     const muscleGroups = await getMuscleGroups(exerciseId);
+
     const exercise = {
       ...data.rows[0],
-      primary: muscleGroups.filter((mg) => mg.group === 'primary'),
-      secondary: muscleGroups.filter((mg) => mg.group === 'secondary'),
+      primary: muscleGroups
+        .filter((mg) => mg.muscle_group === 'primary')
+        .map((mg) => {
+          return {
+            name: mg.muscle_group_name,
+            description: mg.muscle_group_description,
+            muscle_group_id: mg.muscle_group_id,
+            group: mg.muscle_group,
+          };
+        }),
+      secondary: muscleGroups
+        .filter((mg) => mg.muscle_group === 'secondary')
+        .map((mg) => {
+          return {
+            name: mg.muscle_group_name,
+            description: mg.muscle_group_description,
+            muscle_group_id: mg.muscle_group_id,
+            group: mg.muscle_group,
+          };
+        }),
     };
 
     return res.status(200).json({

--- a/server/src/queries/retrieveExercisesQuery.ts
+++ b/server/src/queries/retrieveExercisesQuery.ts
@@ -36,7 +36,7 @@ export const retrieveExercisesQuery = async (req: Request, res: Response) => {
     FROM exercises e
         LEFT OUTER JOIN exercise_muscle_groups emg
               on emg.exercise_id = e.exercise_id
-                  JOIN muscle_groups mg on mg.muscle_group_id = emg.muscle_group_id
+                LEFT OUTER JOIN muscle_groups mg on mg.muscle_group_id = emg.muscle_group_id
     
     WHERE 
       e.name LIKE '%${req.query.q}%' 
@@ -68,7 +68,7 @@ export const retrieveExercisesQuery = async (req: Request, res: Response) => {
     FROM exercises e
         LEFT OUTER JOIN exercise_muscle_groups emg
               on emg.exercise_id = e.exercise_id
-                  JOIN muscle_groups mg on mg.muscle_group_id = emg.muscle_group_id`;
+                LEFT OUTER JOIN muscle_groups mg on mg.muscle_group_id = emg.muscle_group_id`;
 
   const accountId = res.locals.state.account.account_id;
   const params = [accountId];
@@ -101,8 +101,8 @@ export const retrieveExercisesQuery = async (req: Request, res: Response) => {
               )
               .map((mg) => {
                 return {
-                  name: mg.name,
-                  description: mg.description,
+                  name: mg.muscle_group_name,
+                  description: mg.muscle_group_description,
                   muscle_group_id: mg.muscle_group_id,
                   group: mg.muscle_group,
                 };
@@ -110,12 +110,13 @@ export const retrieveExercisesQuery = async (req: Request, res: Response) => {
             secondary: data.rows
               .filter(
                 (e) =>
-                  e.exercise_id === exercise_id && e.muscle_group === 'primary'
+                  e.exercise_id === exercise_id &&
+                  e.muscle_group === 'secondary'
               )
               .map((mg) => {
                 return {
-                  name: mg.name,
-                  description: mg.description,
+                  name: mg.muscle_group_name,
+                  description: mg.muscle_group_description,
                   muscle_group_id: mg.muscle_group_id,
                   group: mg.muscle_group,
                 };


### PR DESCRIPTION
Adds the ability to add / remove muscle-groups from an exercise.
You can now update the musclegroups on either the exercise list view or the single exercise view. 
I've hidden the update button on exercises that are "public" which you cannot edit. 

Bugfix:
Fixed query issue where all muscle groups were being returned as the same name as the exercise. 