### PR TITLE
Scheduling

### DIFF
--- a/client/src/features/Schedule.jsx
+++ b/client/src/features/Schedule.jsx
@@ -2,39 +2,62 @@ import React, { useState } from 'react';
 import Calendar from 'react-calendar';
 import Modal from 'features/common/Modal';
 import { Button } from 'features/common/Button';
+import { useScheduleNewWorkoutMutation } from './workouts/api/useScheduleNewWorkoutMutation';
 
-export const Schedule = () => {
+export const Schedule = ({ workoutId }) => {
+  const [isOpen, setIsOpen] = useState(false);
   const [value, onChange] = useState(new Date());
+
+  const { data, isError, isLoading, mutate } =
+    useScheduleNewWorkoutMutation(workoutId);
 
   const currentDate = new Date();
 
-  return (
-    <Modal
-      title="Schedule"
-      description="Schedule a workout"
-      closeModal={() => console.log('closed')}
-      isOpen={true}
-    >
-      <Calendar
-        onChange={onChange}
-        value={value}
-        maxDetail="month"
-        minDetail="month"
-        maxDate={new Date(currentDate.setMonth(currentDate.getMonth() + 3))}
-        minDate={new Date()}
-        next2Label=""
-        prev2Label=""
-        nextLabel=""
-        prevLabel=""
-        tileClassName={({ activeStartDate, date, view }) => {
-          return null;
-        }}
-        tileDisabled={({ activeStartDate, date, view }) => {
-          return null;
-        }}
-      />
+  const handleScheduling = () => {
+    // format date YYYY-MM-DD
+    const date = value.toISOString().split('T')[0];
+    mutate({
+      date,
+    });
+  };
 
-      <Button className="w-full mt-2">Schedule</Button>
-    </Modal>
+  return (
+    <>
+      <button
+        className="bg-white mt-2 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow w-32"
+        onClick={() => setIsOpen(true)}
+      >
+        Schedule
+      </button>
+      <Modal
+        title="Schedule"
+        description="Schedule a workout"
+        closeModal={() => setIsOpen(false)}
+        isOpen={isOpen}
+      >
+        <Calendar
+          onChange={onChange}
+          value={value}
+          maxDetail="month"
+          minDetail="month"
+          maxDate={new Date(currentDate.setMonth(currentDate.getMonth() + 3))}
+          minDate={new Date()}
+          next2Label=""
+          prev2Label=""
+          nextLabel=""
+          prevLabel=""
+          tileClassName={({ activeStartDate, date, view }) => {
+            return null;
+          }}
+          tileDisabled={({ activeStartDate, date, view }) => {
+            return null;
+          }}
+        />
+
+        <Button className="w-full mt-2" onClick={handleScheduling}>
+          Schedule
+        </Button>
+      </Modal>
+    </>
   );
 };

--- a/client/src/features/feed/Feed.jsx
+++ b/client/src/features/feed/Feed.jsx
@@ -5,7 +5,7 @@ import { getFutureDate, isToday } from './utils';
 
 export const Feed = ({ workouts }) => {
   return (
-    <div className="pb-10">
+    <div className="pb-10 w-full">
       {Array.of(0, 1, 2, 3, 4, 5, 6).map((day) => {
         if (day === 0) {
           return (

--- a/client/src/features/feed/Panel.jsx
+++ b/client/src/features/feed/Panel.jsx
@@ -21,7 +21,7 @@ export const Panel = ({ workouts, day }) => {
 
 const RestDay = () => {
   return (
-    <div className="w-80 my-4 px-2">
+    <div className="my-4 px-2">
       <div className="flex flex-row items-start gap-4 px-2">
         <div className="w-full flex flex-row justify-between">
           <div className="pt-2 w-40">
@@ -58,10 +58,10 @@ const ScheduleNextDay = ({ day }) => {
   };
 
   return (
-    <div className="w-80 my-4 px-2">
+    <div className="my-4 px-2">
       <div className="flex flex-row items-start gap-4 px-2">
         <div className="w-full flex flex-row justify-between">
-          <div className="pt-2 w-80">
+          <div className="pt-2">
             <p className="text-xl font-medium">Schedule your next workout</p>
             <Link href="/workouts">
               <button className="bg-white mt-2 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow w-32">
@@ -94,7 +94,7 @@ const ScheduledWorkouts = ({ workouts }) => {
 
   return workouts.map((w) => {
     return (
-      <div className="w-80 mt-2 px-2 py-4" key={w.workout_id}>
+      <div className="mt-2 px-2 py-4" key={w.workout_id}>
         <div className="flex flex-row items-start gap-4">
           <div className="w-full flex flex-row justify-between">
             <div className="pt-2 w-52">

--- a/client/src/features/workouts/api/useScheduleNewWorkoutMutation.jsx
+++ b/client/src/features/workouts/api/useScheduleNewWorkoutMutation.jsx
@@ -1,0 +1,18 @@
+import { useMutation } from 'react-query';
+
+const scheduleNewWorkout = async ({ id, date }) => {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/workouts/${id}/copy?date=${date}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+    }
+  );
+  const json = await res.json();
+  return json;
+};
+
+export const useScheduleNewWorkoutMutation = (id) => {
+  return useMutation(({ date }) => scheduleNewWorkout({ id, date }));
+};

--- a/client/src/features/workouts/components/GetFutureWorkouts.jsx
+++ b/client/src/features/workouts/components/GetFutureWorkouts.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useFutureWorkoutsQuery } from 'features/workouts/api/useWorkoutsQuery';
+import { Feed } from 'features/feed/Feed';
+
+export const GetFutureWorkouts = () => {
+  const { data, isError, isLoading } = useFutureWorkoutsQuery();
+
+  if (isLoading) {
+    return <p>loading...</p>;
+  }
+
+  if (isError) {
+    return <p style={{ color: 'red' }}>fetching error...</p>;
+  }
+
+  if (!data.workouts) {
+    return <p>none available...</p>;
+  }
+
+  return <Feed workouts={data.workouts} />;
+};

--- a/client/src/features/workouts/components/WorkoutList.jsx
+++ b/client/src/features/workouts/components/WorkoutList.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import Link from 'next/link';
 import { DeleteWorkout } from 'features/workouts/components/DeleteWorkout';
 import Overview from 'features/workout-overview/Overview';
+import { Schedule } from 'features/Schedule';
 
 export const WorkoutList = ({ workouts }) => {
+  console.log({ workouts });
   return (
     <section className="divide-y-2 divide-gray-100">
       {workouts.map((workout) => (
@@ -17,10 +19,18 @@ export const WorkoutList = ({ workouts }) => {
               <p>{workout.category}</p>
               <p>{workout.description}</p>
               <p>{workout.workout_id}</p>
+              <p>
+                {workout.workout_dt &&
+                  new Intl.DateTimeFormat('en-US', {
+                    month: 'short',
+                    day: '2-digit',
+                  }).format(new Date(workout.workout_dt))}
+              </p>
             </div>
           </Link>
           <DeleteWorkout workoutId={workout.workout_id} />
           <Overview workout={workout} workoutId={workout.workout_id} />
+          <Schedule workoutId={workout.workout_id} />
         </article>
       ))}
     </section>

--- a/client/src/pages/index.jsx
+++ b/client/src/pages/index.jsx
@@ -1,26 +1,11 @@
 import React from 'react';
-import { useFutureWorkoutsQuery } from 'features/workouts/api/useWorkoutsQuery';
-import Overview from 'features/workout-overview/Overview';
 import Layout from 'features/common/Layout';
+import { GetFutureWorkouts } from 'features/workouts/components/GetFutureWorkouts';
 
 function HomePage() {
-  const { data, isError, isLoading } = useFutureWorkoutsQuery();
-
-  if (isLoading) {
-    return <p>loading...</p>;
-  }
-
-  if (isError) {
-    return <p style={{ color: 'red' }}>fetching error...</p>;
-  }
-
-  if (!data.workouts) {
-    return <p>none available...</p>;
-  }
-
   return (
     <Layout>
-      <Overview workoutId={100} />
+      <GetFutureWorkouts />
     </Layout>
   );
 }

--- a/server/src/routes/workouts/index.ts
+++ b/server/src/routes/workouts/index.ts
@@ -12,6 +12,7 @@ import setsRouter from './sets';
 import exercisesRouter from './exercises';
 import startWorkoutRouter from './start';
 import endWorkoutRouter from './end';
+import { cloneScheduleWorkoutMutation } from 'queries/cloneScheduleMutation';
 
 const router = Router();
 
@@ -38,9 +39,20 @@ router.post('/', authenticate, authorize, async (req, res) => {
   await createWorkoutMutation(res, req.body);
 });
 
-// Clone workout
+// Clone OR schedule workout ------------ /
+// Schedule todays workout -------------- /?date=today
+// Schedule tomorrows workout ----------- /?date=tomorrow
+// Schedule workout at a specific date -- /?date=YYYY-MM-DD
 router.post('/:workoutId/copy', authenticate, async (req, res) => {
-  await cloneWorkoutMutation(res, req.params.workoutId);
+  if (!!req.query.date) {
+    await cloneScheduleWorkoutMutation(
+      res,
+      req.params.workoutId,
+      req.query.date as string
+    );
+  } else {
+    await cloneWorkoutMutation(res, req.params.workoutId);
+  }
 });
 
 // Delete workout


### PR DESCRIPTION
In this PR, I've added back in scheduling workouts. You can now click on the scheduling button on the homepage, which will redirect you to the workouts page. Clicking schedule on a workout brings up a calendar which you can select a day to schedule the workout. 

Under the hood, scheduling the workout clones the selected workouts information but updates the `workout_dt` timestamp. You can then see the state of your schedule update on the homepage if you've scheduled a workout during the following week. 

### Altered API routes
- Clone OR schedule workout - 
`POST /workout/:pk/copy`
`POST /workout/:pk/copy?date=tomorrow`
`POST /workout/:pk/copy?date=2022-04-20`