### PR TITLE
Adds session preview dots under dates in horizontal scroller

### DIFF
--- a/client/src/features/common/Header.jsx
+++ b/client/src/features/common/Header.jsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { RiUser3Line, RiSearchLine } from 'react-icons/ri';
 import Link from 'next/link';
 import dynamic from 'next/dynamic';
+import { usePreviewWorkoutsQuery } from 'features/workouts/api/useWorkoutsQuery';
+import { generateCalendarState } from 'features/date-scroll/generateCalendarState';
 
 const ScrollDatePicker = dynamic(
   import('../date-scroll/ScrollDatePicker').then((mod) => mod.ScrollDatePicker),
@@ -9,6 +11,28 @@ const ScrollDatePicker = dynamic(
 );
 
 export const Header = () => {
+  // state used to generate the array of calendar dates (+1 / -1 months)
+  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [items, setItems] = useState(generateCalendarState(selectedDate));
+
+  // the day selected by the user
+  const [selected, setSelected] = useState({});
+
+  const { data, isError, isLoading } = usePreviewWorkoutsQuery({
+    items,
+    date: new Date(
+      new Intl.DateTimeFormat('en-CA', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      }).format(
+        selected.id
+          ? new Date(selected.year, selected.month - 1, selected.day)
+          : new Date()
+      )
+    ).toISOString(),
+  });
+
   return (
     <nav className="dark:bg-gray-900 p-2 bg-white shadow md:flex md:items-center md:justify-between md:p-6 fixed top-0 left-0 w-full z-10">
       <div className="max-w-7xl mx-auto px-2 sm:px-6 lg:px-8 text-gray-300">
@@ -47,7 +71,17 @@ export const Header = () => {
         </div>
       </div>
 
-      <ScrollDatePicker />
+      <ScrollDatePicker
+        selectedDate={selectedDate}
+        setSelectedDate={setSelectedDate}
+        items={items}
+        setItems={setItems}
+        selected={selected}
+        setSelected={setSelected}
+        data={data}
+        isError={isError}
+        isLoading={isLoading}
+      />
     </nav>
   );
 };

--- a/client/src/features/workouts/api/useWorkoutsQuery.jsx
+++ b/client/src/features/workouts/api/useWorkoutsQuery.jsx
@@ -3,7 +3,9 @@ import { useQuery } from 'react-query';
 const fetchWorkouts = async ({ activity, type, category, sortBy }) => {
   try {
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_ENDPOINT}/workouts/?category=${category}&type=${type}&activity=${activity}&sortBy=${sortBy}`,
+      `${process.env.NEXT_PUBLIC_API_ENDPOINT}/workouts/?category=${
+        category ?? ''
+      }&type=${type ?? ''}&activity=${activity ?? ''}&sortBy=${sortBy ?? ''}`,
       {
         credentials: 'include',
       }
@@ -38,4 +40,34 @@ const fetchFutureWorkouts = async () => {
 
 export const useFutureWorkoutsQuery = () => {
   return useQuery('fetchFutureWorkouts', fetchFutureWorkouts);
+};
+
+const fetchPreviewWorkouts = async ({ date }) => {
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_ENDPOINT}/workouts/preview?date=${date}`,
+      {
+        credentials: 'include',
+      }
+    );
+    const json = await res.json();
+    return json;
+  } catch (error) {
+    throw new Error(error);
+  }
+};
+
+export const usePreviewWorkoutsQuery = ({ date, items }) => {
+  const filteredItem = items.filter(
+    (item) =>
+      item.month === new Date(date).getMonth() + 1 &&
+      item.year === new Date(date).getFullYear() &&
+      item.day === new Date(date).getDate()
+  );
+
+  const doesItemNotExist = !filteredItem.length;
+
+  return useQuery(['fetchPreviewWorkouts', doesItemNotExist, items], () =>
+    fetchPreviewWorkouts({ date })
+  );
 };

--- a/client/src/pages/index.jsx
+++ b/client/src/pages/index.jsx
@@ -4,7 +4,7 @@ import Layout from 'features/common/Layout';
 function HomePage() {
   return (
     <Layout>
-      <div className="border-b border-slate-400">
+      {/* <div className="border-b border-slate-400">
         <div className="h-32 flex justify-center pt-4">
           <div className="w-24 h-24 rounded-full flex flex-col justify-center items-center bg-slate-900 text-slate-400">
             <div className="text-white py-1">0</div>
@@ -70,7 +70,7 @@ function HomePage() {
             No steps tracked for today
           </div>
         </div>
-      </div>
+      </div> */}
     </Layout>
   );
 }

--- a/client/src/pages/index.jsx
+++ b/client/src/pages/index.jsx
@@ -4,7 +4,7 @@ import Layout from 'features/common/Layout';
 function HomePage() {
   return (
     <Layout>
-      {/* <div className="border-b border-slate-400">
+      <div className="border-b border-slate-400">
         <div className="h-32 flex justify-center pt-4">
           <div className="w-24 h-24 rounded-full flex flex-col justify-center items-center bg-slate-900 text-slate-400">
             <div className="text-white py-1">0</div>
@@ -70,7 +70,7 @@ function HomePage() {
             No steps tracked for today
           </div>
         </div>
-      </div> */}
+      </div>
     </Layout>
   );
 }

--- a/server/src/queries/workouts/retrievePreviewWorkoutsQuery.ts
+++ b/server/src/queries/workouts/retrievePreviewWorkoutsQuery.ts
@@ -1,0 +1,36 @@
+import { db } from 'config/db';
+import { Request, Response } from 'express';
+
+export const retrievePreviewWorkoutsQuery = async (
+  req: Request,
+  res: Response
+) => {
+  // ex. Wed Apr 20 2022 19:50:53 GMT-0700 (Pacific Daylight Time)
+  const selectedDateQuery = req.query.date as string;
+
+  const accountId = res.locals.state.account.account_id;
+  const query = `
+    SELECT workout_id, workout_dt, type FROM workouts 
+    WHERE created_by = ${accountId} AND 
+    DATE_TRUNC('month', workout_dt) 
+        BETWEEN TIMESTAMP '${selectedDateQuery}' - INTERVAL '2 month' AND TIMESTAMP '${selectedDateQuery}' + INTERVAL '1 month'
+  `;
+
+  try {
+    const data = await db.query(query);
+
+    return res.status(200).json({
+      role: res.locals.state.account.role,
+      message: 'Workouts fetched successfully',
+      status: 'success',
+      workouts: data.rows,
+    });
+  } catch (error) {
+    console.log({ error });
+    return res.status(500).json({
+      status: 'error',
+      message: 'Database error',
+      workouts: null,
+    });
+  }
+};

--- a/server/src/routes/workouts/index.ts
+++ b/server/src/routes/workouts/index.ts
@@ -17,6 +17,7 @@ import { createRestWorkoutMutation } from 'queries/workouts/createRestWorkoutMut
 import { createDeloadWorkoutMutation } from 'queries/workouts/createDeloadWorkoutMutation';
 import { createCardioWorkoutMutation } from 'queries/workouts/createCardioWorkoutMutation';
 import { createTherapyWorkoutMutation } from 'queries/workouts/createTherapyWorkoutMutation';
+import { retrievePreviewWorkoutsQuery } from 'queries/workouts/retrievePreviewWorkoutsQuery';
 
 const router = Router();
 
@@ -34,6 +35,10 @@ const router = Router();
 // Retrieve workout(s) sorted by ----------- /?sortBy=created-asc (created-asc, created-desc, updated-asc, updated-descm scheduled-asc, scheduled-desc)
 router.get('/', authenticate, async (req, res) => {
   await retrieveWorkoutsQuery(req, res);
+});
+
+router.get('/preview', authenticate, async (req, res) => {
+  await retrievePreviewWorkoutsQuery(req, res);
 });
 
 // Retrieve workout


### PR DESCRIPTION
In this PR I've added preview dots under the horizontal scroll bar. 

When you schedule workouts, you should now see dots representing different types of workouts.
```
const getHighlightColor = (type) => {
  switch (type) {
    case 'cardio':
      return 'bg-yellow-300';
    case 'strength':
      return 'bg-green-300';
    case 'therapy':
      return 'bg-pink-400';
    case 'deload':
      return 'bg-red-500';
    default:
      return 'bg-green-300';
  }
};
```

You should also notice that multiple sessions can be scheduled for the same day (so can multiple dots). 

![preview-dates-sessions](https://user-images.githubusercontent.com/49698819/164481823-ee63f837-f99e-42e0-8267-f947274f20f6.PNG)
