### PR TITLE
Fixes dev environment + Axios

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^0.27.1",
         "next": "^12.1.0",
         "react": "^17.0.2",
         "react-calendar": "^3.7.0",
@@ -1310,6 +1311,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "node_modules/atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -1355,6 +1361,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.1.tgz",
+      "integrity": "sha512-ePNMai55xo5GsXajb/k756AqZqpqeDaGwGcdvbZLSSELbbYwsIn2jNmGfUPEwd8j/yu4OoMstLLIVa4t0MneEA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1629,6 +1644,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/compute-scroll-into-view": {
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
@@ -1787,6 +1813,14 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
@@ -3551,6 +3585,38 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.3.tgz",
@@ -4549,6 +4615,25 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
       "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
@@ -7142,6 +7227,11 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -7166,6 +7256,15 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.1.tgz",
+      "integrity": "sha512-ePNMai55xo5GsXajb/k756AqZqpqeDaGwGcdvbZLSSELbbYwsIn2jNmGfUPEwd8j/yu4OoMstLLIVa4t0MneEA==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -7377,6 +7476,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "compute-scroll-into-view": {
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
@@ -7503,6 +7610,11 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detect-node": {
       "version": "2.1.0",
@@ -8841,6 +8953,21 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fraction.js": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.3.tgz",
@@ -9571,6 +9698,19 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
       "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
     },
     "mimic-fn": {
       "version": "2.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^0.27.1",
     "next": "^12.1.0",
     "react": "^17.0.2",
     "react-calendar": "^3.7.0",

--- a/client/src/config/axios.jsx
+++ b/client/src/config/axios.jsx
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export const apiClient = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_ENDPOINT,
+  withCredentials: true,
+});

--- a/client/src/features/account/api/useAccountFieldMutation.jsx
+++ b/client/src/features/account/api/useAccountFieldMutation.jsx
@@ -1,24 +1,9 @@
 import { useMutation } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const updateField = async (payload) => {
-  try {
-    // fetch the data, the fetch call returns a promise of a response.
-    // we await for the promise to resolve with the await keyword.
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_ENDPOINT}/auth/me`, {
-      method: 'PATCH',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
-
-    // once we have the response, we need to turn it into JSON.
-    const json = await res.json();
-
-    // return the data that we got from the API.
-    return json;
-  } catch (error) {
-    throw new Error(error);
-  }
+  const { data } = await apiClient.patch(`/auth/me`, payload);
+  return data;
 };
 
 export const useAccountFieldMutation = () => {

--- a/client/src/features/account/api/useAccountQuery.jsx
+++ b/client/src/features/account/api/useAccountQuery.jsx
@@ -1,21 +1,9 @@
 import { useQuery } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const fetchAccount = async () => {
-  try {
-    // fetch the data, the fetch call returns a promise of a response.
-    // we await for the promise to resolve with the await keyword.
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_ENDPOINT}/auth/me`, {
-      credentials: 'include',
-    });
-
-    // once we have the response, we need to turn it into JSON.
-    const json = await res.json();
-
-    // return the data that we got from the API.
-    return json;
-  } catch (error) {
-    throw new Error(error);
-  }
+  const { data } = await apiClient.get(`/auth/me`);
+  return data;
 };
 
 export const useAccountQuery = () => {

--- a/client/src/features/daily/GetSelectedDailyOverview.jsx
+++ b/client/src/features/daily/GetSelectedDailyOverview.jsx
@@ -5,7 +5,7 @@ import { DietPanel } from 'features/daily/DietPanel';
 import { TrainingPanel } from 'features/daily/TrainingPanel';
 
 export const GetSelectedDailyOverview = ({ selected }) => {
-  const { data, isError, isLoading } = useDailyOverviewQuery(selected);
+  const { data, isError, isLoading, error } = useDailyOverviewQuery(selected);
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -15,7 +15,7 @@ export const GetSelectedDailyOverview = ({ selected }) => {
     return <div>Error</div>;
   }
 
-  console.log({ data });
+  console.log({ data, isError, error });
 
   return (
     <section className="flex w-100 items-center justify-center">

--- a/client/src/features/daily/useDailyOverviewQuery.jsx
+++ b/client/src/features/daily/useDailyOverviewQuery.jsx
@@ -1,14 +1,12 @@
+import { apiClient } from 'config/axios';
 import { useQuery } from 'react-query';
 
 const fetchDailyOverview = async ({ date, start, end }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/overview?date=${date}&startTime=${start}&endTime=${end}`,
-    {
-      credentials: 'include',
-    }
+  const { data } = await apiClient.get(
+    `/overview?date=${date}&startTime=${start}&endTime=${end}`
   );
-  const json = await res.json();
-  return json;
+
+  return data;
 };
 
 export const useDailyOverviewQuery = (selected) => {

--- a/client/src/features/date-scroll/usePreviewWorkoutsQuery.jsx
+++ b/client/src/features/date-scroll/usePreviewWorkoutsQuery.jsx
@@ -1,18 +1,9 @@
 import { useQuery } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const fetchPreviewWorkouts = async ({ date }) => {
-  try {
-    const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_ENDPOINT}/sessions/preview?date=${date}`,
-      {
-        credentials: 'include',
-      }
-    );
-    const json = await res.json();
-    return json;
-  } catch (error) {
-    throw new Error(error);
-  }
+  const { data } = await apiClient.get(`/sessions/preview?date=${date}`);
+  return data;
 };
 
 export const usePreviewWorkoutsQuery = ({ date, items }) => {

--- a/client/src/features/exercises/api/useAddMuscleGroupToExerciseMutation.jsx
+++ b/client/src/features/exercises/api/useAddMuscleGroupToExerciseMutation.jsx
@@ -1,21 +1,16 @@
-import { useMutation, useQueryClient } from 'react-query';
+import { apiClient } from 'config/axios';
+import { useMutation } from 'react-query';
 
 const addMuscleGroupToExercise = async ({ exerciseId, payload }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/exercises/${exerciseId}/muscle-group/`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-      credentials: 'include',
-    }
+  const { data } = await apiClient.post(
+    `/exercises/${exerciseId}/muscle-group/`,
+    payload
   );
-  const json = await res.json();
-  return json;
+
+  return data;
 };
 
 export const useAddMuscleGroupToExerciseMutation = (exerciseId) => {
-  const queryClient = useQueryClient();
   return useMutation((payload) =>
     addMuscleGroupToExercise({ exerciseId, payload })
   );

--- a/client/src/features/exercises/api/useCreateExerciseMutation.jsx
+++ b/client/src/features/exercises/api/useCreateExerciseMutation.jsx
@@ -1,17 +1,9 @@
 import { useMutation } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const createExercise = async ({ exercise }) => {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_ENDPOINT}/exercises`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(exercise),
-    credentials: 'include',
-  });
-  if (!res.ok) {
-    throw new Error(res.statusText);
-  }
-  const json = await res.json();
-  return json;
+  const { data } = await apiClient.post(`/exercises`, exercise);
+  return data;
 };
 
 export const useCreateExerciseMutation = () => {

--- a/client/src/features/exercises/api/useDeleteExerciseMutation.jsx
+++ b/client/src/features/exercises/api/useDeleteExerciseMutation.jsx
@@ -1,16 +1,9 @@
 import { useMutation } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const deleteExercise = async ({ id }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/exercises/${id}`,
-    {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-    }
-  );
-  const json = await res.json();
-  return json;
+  const { data } = await apiClient.delete(`/exercises/${id}`);
+  return data;
 };
 
 export const useDeleteExerciseMutation = (id) => {

--- a/client/src/features/exercises/api/useExerciseIdsQuery.jsx
+++ b/client/src/features/exercises/api/useExerciseIdsQuery.jsx
@@ -1,20 +1,13 @@
+import { apiClient } from 'config/axios';
 import { useQuery } from 'react-query';
 
 const fetchExercises = async (ids) => {
   // fetch the data, the fetch call returns a promise of a response.
   // we await for the promise to resolve with the await keyword.
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/exercises/?ids=${ids.join(',')}`,
-    {
-      credentials: 'include',
-    }
-  );
-
-  // once we have the response, we need to turn it into JSON.
-  const json = await res.json();
+  const { data } = await apiClient.get(`/exercises/?ids=${ids.join(',')}`);
 
   // return the data that we got from the API.
-  return json;
+  return data;
 };
 
 export const useExerciseIdsQuery = (ids) => {

--- a/client/src/features/exercises/api/useExerciseQuery.jsx
+++ b/client/src/features/exercises/api/useExerciseQuery.jsx
@@ -1,20 +1,9 @@
 import { useQuery } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const fetchExercise = async ({ id }) => {
-  // fetch the data, the fetch call returns a promise of a response.
-  // we await for the promise to resolve with the await keyword.
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/exercises/${id}`,
-    {
-      credentials: 'include',
-    }
-  );
-
-  // once we have the response, we need to turn it into JSON.
-  const json = await res.json();
-
-  // return the data that we got from the API.
-  return json;
+  const { data } = await apiClient.get(`/exercises/${id}`);
+  return data;
 };
 
 export const useExerciseQuery = (id) => {

--- a/client/src/features/exercises/api/useExercisesQuery.jsx
+++ b/client/src/features/exercises/api/useExercisesQuery.jsx
@@ -1,24 +1,17 @@
 import { useQuery } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const fetchExercises = async ({ query, category, view, profile, sortBy }) => {
-  // fetch the data, the fetch call returns a promise of a response.
-  // we await for the promise to resolve with the await keyword.
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/exercises/?q=${
-      query ?? ''
-    }&category=${category ?? ''}&view=${view ?? ''}&profile=${
-      profile ?? ''
-    }&sortBy=${sortBy ?? ''}`,
+  const { data } = await apiClient.get(
+    `/exercises/?q=${query ?? ''}&category=${category ?? ''}&view=${
+      view ?? ''
+    }&profile=${profile ?? ''}&sortBy=${sortBy ?? ''}`,
     {
       credentials: 'include',
     }
   );
 
-  // once we have the response, we need to turn it into JSON.
-  const json = await res.json();
-
-  // return the data that we got from the API.
-  return json;
+  return data;
 };
 
 export const useExercisesQuery = ({

--- a/client/src/features/exercises/api/useRelatedExercisesQuery.jsx
+++ b/client/src/features/exercises/api/useRelatedExercisesQuery.jsx
@@ -1,20 +1,9 @@
 import { useQuery } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const fetchExercises = async (ids) => {
-  // fetch the data, the fetch call returns a promise of a response.
-  // we await for the promise to resolve with the await keyword.
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/exercises/?mgIds=${ids.join(',')}`,
-    {
-      credentials: 'include',
-    }
-  );
-
-  // once we have the response, we need to turn it into JSON.
-  const json = await res.json();
-
-  // return the data that we got from the API.
-  return json;
+  const { data } = await apiClient.get(`/exercises/?mgIds=${ids.join(',')}`);
+  return data;
 };
 
 export const useRelatedExercisesQuery = (ids) => {

--- a/client/src/features/exercises/api/useRemoveMuscleGroupFromExerciseMutation.jsx
+++ b/client/src/features/exercises/api/useRemoveMuscleGroupFromExerciseMutation.jsx
@@ -1,3 +1,4 @@
+import { apiClient } from 'config/axios';
 import { useMutation, useQueryClient } from 'react-query';
 
 const removeMuscleGroupFromExercise = async ({
@@ -5,16 +6,11 @@ const removeMuscleGroupFromExercise = async ({
   muscleGroupId,
   group,
 }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/exercises/${exerciseId}/muscle-group/${muscleGroupId}/${group}`,
-    {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-    }
+  const { data } = await apiClient.delete(
+    `/exercises/${exerciseId}/muscle-group/${muscleGroupId}/${group}`
   );
-  const json = await res.json();
-  return json;
+
+  return data;
 };
 
 export const useRemoveMuscleGroupFromExerciseMutation = (exerciseId) => {

--- a/client/src/features/exercises/api/useUpdateExerciseMutation.jsx
+++ b/client/src/features/exercises/api/useUpdateExerciseMutation.jsx
@@ -1,20 +1,9 @@
 import { useMutation } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const updateExercise = async ({ id, exercise }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/exercises/${id}`,
-    {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(exercise),
-      credentials: 'include',
-    }
-  );
-  if (!res.ok) {
-    throw new Error(res.statusText);
-  }
-  const json = await res.json();
-  return json;
+  const { data } = await apiClient.put(`/exercises/${id}`, exercise);
+  return data;
 };
 
 export const useUpdateExerciseMutation = (id) => {

--- a/client/src/features/muscle-groups/api/useCreateMuscleGroupMutation.jsx
+++ b/client/src/features/muscle-groups/api/useCreateMuscleGroupMutation.jsx
@@ -1,17 +1,9 @@
 import { useMutation } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const createMuscleGroup = async ({ muscleGroup }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/muscle-groups`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(muscleGroup),
-      credentials: 'include',
-    }
-  );
-  const json = await res.json();
-  return json;
+  const { data } = await apiClient.post(`/muscle-groups`, muscleGroup);
+  return data;
 };
 
 export const useCreateMuscleGroupMutation = () => {

--- a/client/src/features/muscle-groups/api/useDeleteMuscleGroupMutation.jsx
+++ b/client/src/features/muscle-groups/api/useDeleteMuscleGroupMutation.jsx
@@ -1,16 +1,9 @@
 import { useMutation } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const deleteMuscleGroup = async ({ id }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/muscle-groups/${id}`,
-    {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-    }
-  );
-  const json = await res.json();
-  return json;
+  const { data } = await apiClient.delete(`/muscle-groups/${id}`);
+  return data;
 };
 
 export const useDeleteMuscleGroupMutation = () => {

--- a/client/src/features/muscle-groups/api/useMuscleGroupQuery.jsx
+++ b/client/src/features/muscle-groups/api/useMuscleGroupQuery.jsx
@@ -1,16 +1,9 @@
 import { useQuery } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const fetchMuscleGroup = async ({ id }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/muscle-groups/${id}`,
-    {
-      credentials: 'include',
-    }
-  );
-
-  const json = await res.json();
-
-  return json;
+  const { data } = await apiClient.get(`/muscle-groups/${id}`);
+  return data;
 };
 
 export const useMuscleGroupQuery = (id) => {

--- a/client/src/features/muscle-groups/api/useMuscleGroupsQuery.jsx
+++ b/client/src/features/muscle-groups/api/useMuscleGroupsQuery.jsx
@@ -1,16 +1,12 @@
 import { useQuery } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const fetchMuscleGroups = async () => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/muscle-groups/`,
-    {
-      credentials: 'include',
-    }
+  const { data } = await apiClient.get(
+    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/muscle-groups/`
   );
 
-  const json = await res.json();
-
-  return json;
+  return data;
 };
 
 export const useMuscleGroupsQuery = () => {

--- a/client/src/features/muscle-groups/api/useUpdateMuscleGroupMutation.jsx
+++ b/client/src/features/muscle-groups/api/useUpdateMuscleGroupMutation.jsx
@@ -1,17 +1,9 @@
+import { apiClient } from 'config/axios';
 import { useMutation } from 'react-query';
 
 const updateMuscleGroup = async ({ id, muscleGroup }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/muscle-groups/${id}`,
-    {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(muscleGroup),
-      credentials: 'include',
-    }
-  );
-  const json = await res.json();
-  return json;
+  const { data } = await apiClient.put(`/muscle-groups/${id}`, muscleGroup);
+  return data;
 };
 
 export const useUpdateMuscleGroupMutation = (id) => {

--- a/client/src/features/sessions/SessionTimer.jsx
+++ b/client/src/features/sessions/SessionTimer.jsx
@@ -43,6 +43,8 @@ const SessionTimer = ({ startedAt, workoutId, endedAt }) => {
         credentials: 'include',
       }
     );
+
+    if (!response.ok) throw Error;
     const json = await res.json();
     return json;
   };

--- a/client/src/features/sessions/useSessionExerciseQuery.jsx
+++ b/client/src/features/sessions/useSessionExerciseQuery.jsx
@@ -1,20 +1,12 @@
+import { apiClient } from 'config/axios';
 import { useQuery } from 'react-query';
 
 const fetchSessionExercise = async ({ exerciseId, sessionId }) => {
-  // fetch the data, the fetch call returns a promise of a response.
-  // we await for the promise to resolve with the await keyword.
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/sessions/${sessionId}/exercises/${exerciseId}`,
-    {
-      credentials: 'include',
-    }
+  const { data } = await apiClient.get(
+    `/sessions/${sessionId}/exercises/${exerciseId}`
   );
 
-  // once we have the response, we need to turn it into JSON.
-  const json = await res.json();
-
-  // return the data that we got from the API.
-  return json;
+  return data;
 };
 
 export const useSessionExerciseQuery = (exerciseId, sessionId) => {

--- a/client/src/features/sessions/useSessionQuery.jsx
+++ b/client/src/features/sessions/useSessionQuery.jsx
@@ -1,20 +1,9 @@
 import { useQuery } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const fetchSession = async ({ id }) => {
-  // fetch the data, the fetch call returns a promise of a response.
-  // we await for the promise to resolve with the await keyword.
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/sessions/${id}`,
-    {
-      credentials: 'include',
-    }
-  );
-
-  // once we have the response, we need to turn it into JSON.
-  const json = await res.json();
-
-  // return the data that we got from the API.
-  return json;
+  const { data } = await apiClient.get(`/sessions/${id}`);
+  return data;
 };
 
 export const useSessionQuery = (id) => {

--- a/client/src/features/sets/api/useCreateSetMutation.jsx
+++ b/client/src/features/sets/api/useCreateSetMutation.jsx
@@ -1,17 +1,9 @@
+import { apiClient } from 'config/axios';
 import { useMutation, useQueryClient } from 'react-query';
 
 const createSet = async ({ body, sessionId }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/sessions/${sessionId}/sets`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      credentials: 'include',
-    }
-  );
-  const json = await res.json();
-  return json;
+  const { data } = await apiClient.post(`/sessions/${sessionId}/sets`, body);
+  return data;
 };
 
 export const useCreateSetMutation = ({ sessionId }) => {

--- a/client/src/features/sets/api/useDeleteSetMutation.jsx
+++ b/client/src/features/sets/api/useDeleteSetMutation.jsx
@@ -1,16 +1,11 @@
+import { apiClient } from 'config/axios';
 import { useMutation, useQueryClient } from 'react-query';
 
 const deleteSet = async ({ setId, sessionId }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/sessions/${sessionId}/sets/${setId}`,
-    {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-    }
+  const { data } = await apiClient.delete(
+    `/sessions/${sessionId}/sets/${setId}`
   );
-  const json = await res.json();
-  return json;
+  return data;
 };
 
 export const useDeleteSetMutation = ({ setId, sessionId }) => {

--- a/client/src/features/sets/api/useSetsByExerciseQuery.jsx
+++ b/client/src/features/sets/api/useSetsByExerciseQuery.jsx
@@ -1,20 +1,12 @@
 import { useQuery } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const fetchSetsByExercise = async (exerciseId, sessionId) => {
-  // fetch the data, the fetch call returns a promise of a response.
-  // we await for the promise to resolve with the await keyword.
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/sessions/${sessionId}/exercise/${exerciseId}/sets/`,
-    {
-      credentials: 'include',
-    }
+  const { data } = await apiClient.get(
+    `/sessions/${sessionId}/exercise/${exerciseId}/sets/`
   );
 
-  // once we have the response, we need to turn it into JSON.
-  const json = await res.json();
-
-  // return the data that we got from the API.
-  return json;
+  return data;
 };
 
 export const useSetsByExerciseQuery = ({ sessionId, exerciseId }) => {

--- a/client/src/features/sets/api/useUpdateSetMutation.jsx
+++ b/client/src/features/sets/api/useUpdateSetMutation.jsx
@@ -1,17 +1,11 @@
+import { apiClient } from 'config/axios';
 import { useMutation, useQueryClient } from 'react-query';
 
 const updateSet = async ({ sessionId, body, setId }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/sessions/${sessionId}/sets/${setId}`,
-    {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      credentials: 'include',
-    }
-  );
-  const json = await res.json();
-  return json;
+  const { data } = await apiClient.put(`/sessions/${sessionId}/sets/${setId}`, {
+    body,
+  });
+  return data;
 };
 
 export const useUpdateSetMutation = ({ sessionId, setId }) => {

--- a/client/src/features/workout-creation/useCreateWorkoutMutation.jsx
+++ b/client/src/features/workout-creation/useCreateWorkoutMutation.jsx
@@ -1,14 +1,11 @@
 import { useMutation } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const createWorkout = async ({ workout }) => {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_ENDPOINT}/workouts`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(workout),
-    credentials: 'include',
+  const { data } = await apiClient.post(`/workouts`, {
+    workout,
   });
-  const json = await res.json();
-  return json;
+  return data;
 };
 
 export const useCreateWorkoutMutation = () => {

--- a/client/src/features/workout-exercises/api/useAddExerciseToWorkoutMutation.jsx
+++ b/client/src/features/workout-exercises/api/useAddExerciseToWorkoutMutation.jsx
@@ -1,17 +1,12 @@
+import { apiClient } from 'config/axios';
 import { useMutation, useQueryClient } from 'react-query';
 
 const addExerciseToWorkout = async ({ workoutId, payload }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/workouts/${workoutId}/exercises/`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-      credentials: 'include',
-    }
+  const { data } = await apiClient.post(
+    `/workouts/${workoutId}/exercises/`,
+    payload
   );
-  const json = await res.json();
-  return json;
+  return data;
 };
 
 export const useAddExerciseToWorkoutMutation = () => {

--- a/client/src/features/workout-exercises/api/useRemoveExerciseFromWorkoutMutation.jsx
+++ b/client/src/features/workout-exercises/api/useRemoveExerciseFromWorkoutMutation.jsx
@@ -1,16 +1,11 @@
 import { useMutation } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const removeExerciseFromWorkout = async ({ workoutId, exerciseId }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/workouts/${workoutId}/exercises/${exerciseId}`,
-    {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-    }
+  const { data } = await apiClient.delete(
+    `/workouts/${workoutId}/exercises/${exerciseId}`
   );
-  const json = await res.json();
-  return json;
+  return data;
 };
 
 export const useRemoveExerciseFromWorkoutMutation = () => {

--- a/client/src/features/workout-exercises/api/useUpdateWorkoutExerciseMetadataMutation.jsx
+++ b/client/src/features/workout-exercises/api/useUpdateWorkoutExerciseMetadataMutation.jsx
@@ -1,21 +1,16 @@
 import { useMutation } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const updateWorkoutExerciseMetadata = async ({
   workoutId,
   exerciseId,
   body,
 }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/workouts/${workoutId}/exercises/${exerciseId}`,
-    {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      credentials: 'include',
-    }
+  const { data } = await apiClient.patch(
+    `/workouts/${workoutId}/exercises/${exerciseId}`,
+    body
   );
-  const json = await res.json();
-  return json;
+  return data;
 };
 
 export const useUpdateWorkoutExerciseMetadataMutation = ({

--- a/client/src/features/workout-exercises/api/useUpdateWorkoutExerciseMutation.jsx
+++ b/client/src/features/workout-exercises/api/useUpdateWorkoutExerciseMutation.jsx
@@ -1,18 +1,12 @@
+import { apiClient } from 'config/axios';
 import { useMutation } from 'react-query';
 
 const updateWorkoutExercise = async ({ workoutId, exerciseId, payload }) => {
-  console.log({ payload });
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/workouts/${workoutId}/exercises/${exerciseId}/`,
-    {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-      credentials: 'include',
-    }
+  const { data } = await apiClient.put(
+    `/workouts/${workoutId}/exercises/${exerciseId}/`,
+    payload
   );
-  const json = await res.json();
-  return json;
+  return data;
 };
 
 export const useUpdateWorkoutExerciseMutation = (workoutId, exerciseId) => {

--- a/client/src/features/workout-overview/useWorkoutSessionQuery.jsx
+++ b/client/src/features/workout-overview/useWorkoutSessionQuery.jsx
@@ -1,16 +1,9 @@
 import { useQuery } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const fetchWorkoutSession = async ({ id }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/sessions/${id}`,
-    {
-      credentials: 'include',
-    }
-  );
-
-  const json = await res.json();
-
-  return json;
+  const { data } = await apiClient.get(`/sessions/${id}`);
+  return data;
 };
 
 export const useWorkoutSessionQuery = (id) => {

--- a/client/src/features/workouts/api/useCloneWorkoutMutation.jsx
+++ b/client/src/features/workouts/api/useCloneWorkoutMutation.jsx
@@ -1,16 +1,9 @@
 import { useMutation } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const cloneWorkout = async ({ id }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/workouts/${id}/copy`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-    }
-  );
-  const json = await res.json();
-  return json;
+  const { data } = await apiClient.post(`/workouts/${id}/copy`);
+  return data;
 };
 
 export const useCloneWorkoutMutation = (id) => {

--- a/client/src/features/workouts/api/useDeleteWorkoutMutation.jsx
+++ b/client/src/features/workouts/api/useDeleteWorkoutMutation.jsx
@@ -1,16 +1,9 @@
 import { useMutation } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const deleteWorkout = async ({ id }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/workouts/${id}`,
-    {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-    }
-  );
-  const json = await res.json();
-  return json;
+  const { data } = await apiClient.delete(`/workouts/${id}`);
+  return data;
 };
 
 export const useDeleteWorkoutMutation = (id) => {

--- a/client/src/features/workouts/api/useUpdateWorkoutMutation.jsx
+++ b/client/src/features/workouts/api/useUpdateWorkoutMutation.jsx
@@ -1,17 +1,9 @@
 import { useMutation } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const updateWorkout = async ({ id, workout }) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/workouts/${id}`,
-    {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(workout),
-      credentials: 'include',
-    }
-  );
-  const json = await res.json();
-  return json;
+  const { data } = await apiClient.put(`/workouts/${id}`, workout);
+  return data;
 };
 
 export const useUpdateWorkoutMutation = (id) => {

--- a/client/src/features/workouts/api/useWorkoutQuery.jsx
+++ b/client/src/features/workouts/api/useWorkoutQuery.jsx
@@ -1,20 +1,9 @@
 import { useQuery } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const fetchWorkout = async ({ id }) => {
-  // fetch the data, the fetch call returns a promise of a response.
-  // we await for the promise to resolve with the await keyword.
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_ENDPOINT}/workouts/${id}`,
-    {
-      credentials: 'include',
-    }
-  );
-
-  // once we have the response, we need to turn it into JSON.
-  const json = await res.json();
-
-  // return the data that we got from the API.
-  return json;
+  const { data } = await apiClient.get(`/workouts/${id}`);
+  return data;
 };
 
 export const useWorkoutQuery = (id) => {

--- a/client/src/features/workouts/api/useWorkoutsQuery.jsx
+++ b/client/src/features/workouts/api/useWorkoutsQuery.jsx
@@ -1,20 +1,14 @@
 import { useQuery } from 'react-query';
+import { apiClient } from 'config/axios';
 
 const fetchWorkouts = async ({ view, type, category, sortBy }) => {
-  try {
-    const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_ENDPOINT}/workouts/?category=${
-        category ?? ''
-      }&type=${type ?? ''}&view=${view ?? ''}&sortBy=${sortBy ?? ''}`,
-      {
-        credentials: 'include',
-      }
-    );
-    const json = await res.json();
-    return json;
-  } catch (error) {
-    throw new Error(error);
-  }
+  const { data } = await apiClient.get(
+    `/workouts/?category=${category ?? ''}&type=${type ?? ''}&view=${
+      view ?? ''
+    }&sortBy=${sortBy ?? ''}`
+  );
+
+  return data;
 };
 
 export const useWorkoutsQuery = ({ view, type, category, sortBy }) => {
@@ -24,18 +18,8 @@ export const useWorkoutsQuery = ({ view, type, category, sortBy }) => {
 };
 
 const fetchFutureWorkouts = async () => {
-  try {
-    const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_ENDPOINT}/workouts/?date=future`,
-      {
-        credentials: 'include',
-      }
-    );
-    const json = await res.json();
-    return json;
-  } catch (error) {
-    throw new Error(error);
-  }
+  const { data } = await apiClient.get(`/workouts/?date=future`);
+  return data;
 };
 
 export const useFutureWorkoutsQuery = () => {

--- a/client/src/features/workouts/components/StartWorkout.jsx
+++ b/client/src/features/workouts/components/StartWorkout.jsx
@@ -15,6 +15,8 @@ const StartWorkout = ({ sessionId, hasStarted, hasEnded }) => {
         credentials: 'include',
       }
     );
+
+    if (!response.ok) throw Error;
     const json = await res.json();
     return json;
   };
@@ -27,6 +29,8 @@ const StartWorkout = ({ sessionId, hasStarted, hasEnded }) => {
         credentials: 'include',
       }
     );
+
+    if (!response.ok) throw Error;
     const json = await res.json();
     return json;
   };

--- a/client/src/pages/sessions/[sessionId]/end.jsx
+++ b/client/src/pages/sessions/[sessionId]/end.jsx
@@ -31,6 +31,8 @@ const EndPage = ({ sessionId, endedAt }) => {
         credentials: 'include',
       }
     );
+
+    if (!response.ok) throw Error;
     const json = await res.json();
     return json;
   };

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -6,7 +6,7 @@ const envFile =
     ? `test.env`
     : process.env.NODE_ENV === 'development'
     ? 'development.env'
-    : 'production.env';
+    : '.env';
 dotenv.config({ path: envFile });
 
 export * from './application';


### PR DESCRIPTION
I've fixed the dev environment, you should be able to start the server locally now. 

Changes - 

The `fetch` API doesn't treat 400 status codes like `401` OR `403` as errors and returns them successfully. 
This was why we would see some weird behaviour trying to access resources in the client ( things would error out because we didn't properly null / undefined check ). 

Axios

Axios and fetch are both http clients. The **main** difference between the 2 is that axios treats `401` OR `403` as errors. This means that react-query automatically will pick up on them and redirect to the login page whenever a user isn't logged in. 

We're also able to create an **axios instance** which reduced the amount of code repetition significantly. For example:
```
export const apiClient = axios.create({
  baseURL: process.env.NEXT_PUBLIC_API_ENDPOINT,
  withCredentials: true,
});
```

We no longer need to set the baseURL on every request - 
```
`${process.env.NEXT_PUBLIC_API_ENDPOINT}/auth/me`
---------------------
`/auth/me`
```

We no longer need to set the credentials true on every request - 
```
{ credentials: true }
---------------------

```

We also don't need to `JSON.stringify` the body or manually throw errors if !res.ok to get react-query to pick up on them. 
